### PR TITLE
Bump: version, sha, dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "semantikon" %}
-{% set version = "0.0.21" %}
+{% set version = "0.0.22" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6335ecbde5acdea134e261dfce280868f34093ebb016f3f6ad7043f99ea7a9a0
+  sha256: c9dbb844619c20159dc8407c51a45eab779b1b2b705887a7e2717cbe21c4dfe2
 
 build:
   noarch: python
@@ -27,10 +27,10 @@ requirements:
     - networkx >=3.4.2,<3.5.0
     - numpy >=1.26.3,<2.4.0
     - owlrl >=7.1.2,<7.2.0
-    - pint >=0.23,<=0.24.4
+    - pint >=0.23,<=0.25.0
     - rdflib >=7.1.1,<7.2.0
     - pyshacl >=0.30.0,<=0.30.1
-    - requests >=2.0.0,<2.33.0
+    - requests >=2.28.0,<2.33.0
     - typeguard >=4.0.0,<4.5.0
 
 test:


### PR DESCRIPTION
Note that the lower_bound.env for requests specified 2.28.0, so I increased the lower bound here from 2.0.0 since we don't actually test that.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* ~Bumped the build number (if the version is unchanged)~
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@conda-forge-admin, please rerender
